### PR TITLE
resolved issue Specific Home Screen Redirect after Role Selection #25

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -62,6 +62,7 @@ class _MyAppState extends State<MyApp> {
             PrescriptionHistory.id: (context) => PrescriptionHistory(),
             SamplePatientProfile.id: (context) => SamplePatientProfile(),
             HomePatient.id: (context) => HomePatient(),
+            HomeDoctor.id: (context) => HomeDoctor(),
             DoctorProfile.id: (context) => DoctorProfile(),
             DoctorRegistration.id: (context) => DoctorRegistration(),
             PatientRegistration.id: (context) => PatientRegistration(),

--- a/lib/pages/authentication/splashScreen.dart
+++ b/lib/pages/authentication/splashScreen.dart
@@ -1,9 +1,13 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:soochit/global/myColors.dart';
 import 'package:soochit/global/myStrings.dart';
 import 'package:soochit/pages/authentication/register.dart';
 import 'package:soochit/pages/authentication/signout.dart';
+import 'package:soochit/pages/doctor-specific/homeDoctor.dart';
+import 'package:soochit/pages/patient-specific/homePatient.dart';
 import 'package:soochit/stores/login_store.dart';
 
 class SplashScreen extends StatefulWidget {
@@ -15,12 +19,23 @@ class SplashScreen extends StatefulWidget {
 
 class _SplashScreenState extends State<SplashScreen> {
 
+  void _decideUserRole() async{
+    var firebaseUser = await FirebaseAuth.instance.currentUser();
+    var collectionRef = Firestore.instance.collection('Doctor');
+    var doc = await collectionRef.document(firebaseUser.uid).get();
+    if(doc.exists)
+      Navigator.of(context).pushAndRemoveUntil(MaterialPageRoute(builder: (_) =>  HomeDoctor()), (Route<dynamic> route) => false);
+    else
+      Navigator.of(context).pushAndRemoveUntil(MaterialPageRoute(builder: (_) =>  HomePatient()), (Route<dynamic> route) => false);
+  }
+
   @override
   void initState() {
     super.initState();
     Provider.of<LoginStore>(context, listen: false).isAlreadyAuthenticated().then((result) {
       if (result) {
-        Navigator.of(context).pushAndRemoveUntil(MaterialPageRoute(builder: (_) =>  HomePage()), (Route<dynamic> route) => false);
+        print(result);
+        _decideUserRole();
       } else {
         Navigator.of(context).pushAndRemoveUntil(MaterialPageRoute(builder: (_) =>  Register()), (Route<dynamic> route) => false);
       }

--- a/lib/pages/doctor-specific/doctorRegistration.dart
+++ b/lib/pages/doctor-specific/doctorRegistration.dart
@@ -7,6 +7,7 @@ import 'package:soochit/global/myColors.dart';
 import 'package:soochit/global/mySpaces.dart';
 import 'package:soochit/global/myStrings.dart';
 import 'package:soochit/pages/authentication/signout.dart';
+import 'package:soochit/pages/doctor-specific/homeDoctor.dart';
 
 // Doctor's details -> now in array
 // String name;
@@ -93,7 +94,7 @@ class _DoctorRegistrationState extends State<DoctorRegistration> {
               FlatButton(
                 onPressed: () {
                   _onPressedAddDocDetails();
-                  Navigator.pushNamed(context, HomePage.id);
+                  Navigator.pushNamed(context, HomeDoctor.id);
                 },
                 shape: RoundedRectangleBorder(
                     borderRadius: BorderRadius.circular(MyDimens.double_4)),

--- a/lib/pages/doctor-specific/homeDoctor.dart
+++ b/lib/pages/doctor-specific/homeDoctor.dart
@@ -1,12 +1,14 @@
 import 'package:flutter/material.dart';
 import 'package:soochit/global/myColors.dart';
 import 'package:soochit/global/myDimens.dart';
+import 'package:soochit/pages/authentication/signout.dart';
 import 'package:soochit/pages/doctor-specific/patientHistory.dart';
 import 'package:soochit/pages/doctor-specific/doctorProfile.dart';
 import 'package:soochit/widgets/addPatientDialog.dart';
 
 class HomeDoctor extends StatefulWidget {
   static String id = "homeDoctor";
+
   @override
   _HomeDoctorState createState() => _HomeDoctorState();
 }
@@ -15,12 +17,8 @@ class _HomeDoctorState extends State<HomeDoctor> {
   int pageIndex = 0;
   int firstIconColorInt = 0;
   int secondIconColorInt = 1;
-  List _currentPage = [
-    PatientHistory(), DoctorProfile()
-  ];
-  List _iconColors = [
-    MyColors.white, MyColors.lightPink
-  ];
+  List _currentPage = [PatientHistory(), DoctorProfile()];
+  List _iconColors = [MyColors.white, MyColors.lightPink];
 
   @override
   Widget build(BuildContext context) {
@@ -31,7 +29,9 @@ class _HomeDoctorState extends State<HomeDoctor> {
         actions: [
           Padding(
             padding: EdgeInsets.only(right: MyDimens.double_10),
-            child: Icon(Icons.more_vert, size: MyDimens.double_30),
+            child: GestureDetector(
+                onTap: () => Navigator.pushNamed(context, HomePage.id),
+                child: Icon(Icons.more_vert, size: MyDimens.double_30)),
           )
         ],
       ),
@@ -46,16 +46,30 @@ class _HomeDoctorState extends State<HomeDoctor> {
               mainAxisSize: MainAxisSize.max,
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: <Widget>[
-                IconButton(icon: Icon(Icons.history, color: _iconColors[firstIconColorInt],), onPressed: () {setState(() {
-                  pageIndex = 0;
-                  firstIconColorInt = 0;
-                  secondIconColorInt = 1;
-                });},),
-                IconButton(icon: Icon(Icons.person, color: _iconColors[secondIconColorInt]), onPressed: () {setState(() {
-                  pageIndex = 1;
-                  firstIconColorInt = 1;
-                  secondIconColorInt = 0;
-                });},),
+                IconButton(
+                  icon: Icon(
+                    Icons.history,
+                    color: _iconColors[firstIconColorInt],
+                  ),
+                  onPressed: () {
+                    setState(() {
+                      pageIndex = 0;
+                      firstIconColorInt = 0;
+                      secondIconColorInt = 1;
+                    });
+                  },
+                ),
+                IconButton(
+                  icon: Icon(Icons.person,
+                      color: _iconColors[secondIconColorInt]),
+                  onPressed: () {
+                    setState(() {
+                      pageIndex = 1;
+                      firstIconColorInt = 1;
+                      secondIconColorInt = 0;
+                    });
+                  },
+                ),
               ],
             ),
           ),
@@ -63,10 +77,19 @@ class _HomeDoctorState extends State<HomeDoctor> {
         ),
       ),
       floatingActionButtonLocation: FloatingActionButtonLocation.centerDocked,
-      floatingActionButton: FloatingActionButton(onPressed: () {showAddPatientDialog();}, backgroundColor: MyColors.primaryColor, child: Icon(Icons.add, size: 40),),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () {
+          showAddPatientDialog();
+        },
+        backgroundColor: MyColors.primaryColor,
+        child: Icon(Icons.add, size: 40),
+      ),
     );
   }
-  Future<Dialog> showAddPatientDialog(){
-    return showDialog(context: context, builder: (BuildContext context) => AddPatientDialog());
+
+  Future<Dialog> showAddPatientDialog() {
+    return showDialog(
+        context: context,
+        builder: (BuildContext context) => AddPatientDialog());
   }
 }

--- a/lib/pages/patient-specific/homePatient.dart
+++ b/lib/pages/patient-specific/homePatient.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:soochit/global/myColors.dart';
 import 'package:soochit/global/myDimens.dart';
+import 'package:soochit/pages/authentication/signout.dart';
 import 'package:soochit/pages/patient-specific/medicineDeadlines.dart';
 import 'package:soochit/pages/patient-specific/prescriptionHistory.dart';
 
@@ -30,7 +31,9 @@ class _HomePatientState extends State<HomePatient> {
         actions: [
           Padding(
             padding: EdgeInsets.only(right: MyDimens.double_10),
-            child: Icon(Icons.more_vert, size: MyDimens.double_30),
+            child: GestureDetector(
+              onTap: ()=> Navigator.pushNamed(context, HomePage.id),
+                child: Icon(Icons.more_vert, size: MyDimens.double_30)),
           )
         ],
       ),

--- a/lib/pages/patient-specific/patientRegistration.dart
+++ b/lib/pages/patient-specific/patientRegistration.dart
@@ -7,6 +7,7 @@ import 'package:soochit/global/myColors.dart';
 import 'package:soochit/global/mySpaces.dart';
 import 'package:soochit/global/myStrings.dart';
 import 'package:soochit/pages/authentication/signout.dart';
+import 'package:soochit/pages/patient-specific/homePatient.dart';
 
 // Patient's details -> now in array
 // String name;
@@ -87,7 +88,7 @@ class _PatientRegistrationState extends State<PatientRegistration> {
               FlatButton(
                 onPressed: () {
                   _onPressedAddDocDetails();
-                  Navigator.pushNamed(context, HomePage.id);
+                  Navigator.pushNamed(context, HomePatient.id);
                 },
                 shape: RoundedRectangleBorder(
                     borderRadius: BorderRadius.circular(MyDimens.double_4)),

--- a/lib/stores/login_store.dart
+++ b/lib/stores/login_store.dart
@@ -1,9 +1,12 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:mobx/mobx.dart';
 import 'package:soochit/global/myStrings.dart';
 import 'package:soochit/pages/authentication/register.dart';
 import 'package:soochit/pages/authentication/enterOTP.dart';
+import 'package:soochit/pages/doctor-specific/homeDoctor.dart';
+import 'package:soochit/pages/patient-specific/homePatient.dart';
 import 'package:soochit/pages/welcome.dart';
 import 'package:soochit/widgets/snackbar.dart';
 
@@ -102,9 +105,22 @@ abstract class LoginStoreBase with Store {
 
     firebaseUser = result.user;
 
-    Navigator.of(context).pushAndRemoveUntil(
-        MaterialPageRoute(builder: (_) => Welcome(user: firebaseUser)),
-            (Route<dynamic> route) => false);
+    var collectionDoc = Firestore.instance.collection('Doctor');
+    var collectionPat = Firestore.instance.collection('Patient');
+    var docDoc = await collectionDoc.document(firebaseUser.uid).get();
+    var docPat = await collectionPat.document(firebaseUser.uid).get();
+    if (docDoc.exists)
+      Navigator.of(context).pushAndRemoveUntil(
+          MaterialPageRoute(builder: (_) => HomeDoctor()),
+          (Route<dynamic> route) => false);
+    else if (docPat.exists)
+      Navigator.of(context).pushAndRemoveUntil(
+          MaterialPageRoute(builder: (_) => HomePatient()),
+          (Route<dynamic> route) => false);
+    else
+      Navigator.of(context).pushAndRemoveUntil(
+          MaterialPageRoute(builder: (_) => Welcome(user: firebaseUser)),
+          (Route<dynamic> route) => false);
 
     isLoginLoading = false;
     isOtpLoading = false;
@@ -115,7 +131,7 @@ abstract class LoginStoreBase with Store {
     await _auth.signOut();
     await Navigator.of(context).pushAndRemoveUntil(
         MaterialPageRoute(builder: (_) => Register()),
-            (Route<dynamic> route) => false);
+        (Route<dynamic> route) => false);
     firebaseUser = null;
   }
 }

--- a/lib/widgets/addPatientDialog.dart
+++ b/lib/widgets/addPatientDialog.dart
@@ -16,7 +16,7 @@ class AddPatientDialog extends StatelessWidget {
       elevation: 0.0,
       backgroundColor: MyColors.primaryColor,
       child: Container(
-        height: MediaQuery.of(context).size.height*0.22,
+        height: MediaQuery.of(context).size.height*0.30,
         margin: EdgeInsets.all(20),
         color: MyColors.primaryColor,
         child: Column(
@@ -69,7 +69,7 @@ class AddPatientDialog extends StatelessWidget {
                   },
                   color: MyColors.white,
                   child: Text(
-                    MyStrings.confirmLabel, style: Theme.of(context).textTheme.bodyText1.copyWith(color: MyColors.primaryColor, fontSize: MyDimens.double_17, fontFamily: 'lexendeca'),
+                    MyStrings.confirmLabel, style: Theme.of(context).textTheme.bodyText1.copyWith(color: MyColors.primaryColor, fontSize: MyDimens.double_15, fontFamily: 'lexendeca'),
                   ),
                 )
               ],

--- a/lib/widgets/previousPatientCard.dart
+++ b/lib/widgets/previousPatientCard.dart
@@ -16,7 +16,7 @@ class PreviousPatientCard extends StatelessWidget {
       child: Container(
           padding: EdgeInsets.symmetric(horizontal: MyDimens.double_30),
           height: MyDimens.double_70,
-          width: MediaQuery.of(context).size.width*0.80,
+          width: MediaQuery.of(context).size.width*0.90,
           decoration: BoxDecoration(
             borderRadius: BorderRadius.circular(MyDimens.double_7),
             color: MyColors.lightestPink,


### PR DESCRIPTION
Made changes to the way pages are viewed for registered/new/logged_out user other than redirecting appropriately after role selection

## Issue Fix
Fixes #25

## Screenshots
<!--Please Add Screenshots or Screen Recordings which show the changes that you made.-->
Really no UI added. It was a functionality.

## Description
<!--Please Add a Summary of the changes that you have made.-->
I have made the following changes :+1: 
1. After the user registers, he gets redirected to either the doctor or patient homepage based on his role
2. If a logged-in user closes and opens the app anytime, later on, his details are stored and the same will enable us to directly take him to his dashboard as per his role
3. If a user logs-out, on the next login via OTP, he won't be asked his details or role, because the user already exists 

## Reviewers
<!--Ping specific reviewers-->
@Ajitesh13 @dotrachit Kindly review and merge!
